### PR TITLE
Get lang and type from driver POST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# OS generated files 
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db

--- a/src/engines/php/spellchecker.php
+++ b/src/engines/php/spellchecker.php
@@ -19,8 +19,9 @@ class SpellChecker {
 			exit;
 		}
 
-		$driver = $_POST['driver'];
-		$action = $_POST['action'];
+		$lang = $_POST['driver']['lang'];
+		$driver = $_POST['driver']['type'];
+		$action = $_POST['action'];		
 
 		if (!$driver)
 		{
@@ -36,14 +37,16 @@ class SpellChecker {
 		$this->execute_action($action);
 	}
 
-	public function load_driver($driver = NULL)
+	public function load_driver($driver = NULL, $lang = 'en')
 	{
+
 		require_once 'spellchecker/driver.php';
 		require_once 'spellchecker/driver/'.strtolower($driver).'.php';
 
 		$config = array(
-			'lang' => $_POST['lang']
+			'lang' => $lang
 		);
+		
 		$driver = 'Spellchecker_Driver_'.ucfirst($driver);
 
 		$this->driver = new $driver($config);


### PR DESCRIPTION
Kept getting `There was an error processing the request` and it seems the `driver` key in the POST array actually has a `type` and `lang` key.

![](https://dl.dropbox.com/u/12520837/Screen%20shot%202012-10-26%20at%2011.32.45.png)

Added these as variables when loading driver, added a basic `.gitignore`
