### PR TITLE
The button will now automatically appear in the toolbar.

### DIFF
--- a/src/examples/english/ckeditor/plugins/jqueryspellchecker/plugin.js
+++ b/src/examples/english/ckeditor/plugins/jqueryspellchecker/plugin.js
@@ -37,7 +37,8 @@ CKEDITOR.plugins.add('jqueryspellchecker', {
     editor.ui.addButton('jQuerySpellChecker', {
       label: 'SpellCheck',
       icon: 'spellchecker',
-      command: pluginName
+      command: pluginName,
+      toolbar: 'spellchecker,10'
     });
 
     editor.on('saveSnapshot', function() {


### PR DESCRIPTION
CKEditor 4 offers a new feature which makes is possible for plugin developers to set the position in the toolbar that the button show take. In this way, it is enough to enable the plugin to have it ready, without complex toolbar configuration changes.
