### PR TITLE
Allow force setting language in CKEditor plugin

### DIFF
--- a/src/examples/english/ckeditor/plugins/jqueryspellchecker/plugin.js
+++ b/src/examples/english/ckeditor/plugins/jqueryspellchecker/plugin.js
@@ -88,7 +88,11 @@ CKEDITOR.plugins.add('jqueryspellchecker', {
     t.config.getText = function() {
       return $('<div />').append(t.editor.getData()).text();
     };
-
+    
+    if (t.editor.config.forceSpellingLanguage) {
+    	t.config.lang = t.editor.config.forceSpellingLanguage;
+    }
+    
     t.spellchecker = new $.SpellChecker(t.editor.document.$.body, this.config);
 
     t.spellchecker.on('check.success', function() {


### PR DESCRIPTION
Allow the setting of 'forceSpellingLanguage' in the CKEditor config to force the spell check language
