### PR TITLE
The default configuration is overwritten when creating multiple spellcheckers

### DIFF
--- a/src/js/jquery.spellchecker.js
+++ b/src/js/jquery.spellchecker.js
@@ -649,7 +649,8 @@
     Events.call(this);
 
     this.elements = $(elements).attr('spellcheck', 'false');
-    this.config = $.extend(true, defaultConfig, config);
+    var defaultConfigCopy = $.extend(true, {}, defaultConfig);
+    this.config = $.extend(true, defaultConfigCopy, config);
 
     this.setupWebService();
     this.setupParser();


### PR DESCRIPTION
The default configuration got overwritten/changed. When having more than one spellchecker in the same context, the second spellchecker inherited the first spellchecker's config.
