### PR TITLE
Store ignored words in sessionStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
+# OS generated files 
+.DS_Store*
+ehthumbs.db
+Icon?
+Thumbs.db
+
 _SpecRunner.html
 composer.lock

--- a/src/examples/english/html-pspell.html
+++ b/src/examples/english/html-pspell.html
@@ -17,7 +17,6 @@
     <button id="check-textarea">
       Check Spelling
     </button>&nbsp;
-  </div>
   <script type="text/javascript" src="../../js/libs/jquery/jquery-1.8.2.min.js"></script>
   <script type="text/javascript" src="../../js/jquery.spellchecker.js"></script>
   <script type="text/javascript">

--- a/src/examples/english/multiple-fields.html
+++ b/src/examples/english/multiple-fields.html
@@ -43,7 +43,6 @@
         </button>&nbsp;
       </div>
     </fieldset>
-  </div>
   <script type="text/javascript" src="../../js/libs/jquery/jquery-1.8.2.min.js"></script>
   <script type="text/javascript" src="../../js/jquery.spellchecker.js"></script>
   <script type="text/javascript">

--- a/src/examples/english/text-enchant.html
+++ b/src/examples/english/text-enchant.html
@@ -15,7 +15,6 @@
     <button id="check-textarea">
       Check Spelling
     </button>&nbsp;
-  </div>
   <script type="text/javascript" src="../../js/libs/jquery/jquery-1.8.2.min.js"></script>
   <script type="text/javascript" src="../../js/jquery.spellchecker.js"></script>
   <script type="text/javascript">

--- a/src/examples/english/text-google.html
+++ b/src/examples/english/text-google.html
@@ -15,7 +15,6 @@
     <button id="check-textarea">
       Check Spelling
     </button>&nbsp;
-  </div>
   <script type="text/javascript" src="../../js/libs/jquery/jquery-1.8.2.min.js"></script>
   <script type="text/javascript" src="../../js/jquery.spellchecker.js"></script>
   <script type="text/javascript">

--- a/src/examples/english/text-pspell.html
+++ b/src/examples/english/text-pspell.html
@@ -15,7 +15,6 @@
     <button id="check-textarea">
       Check Spelling
     </button>&nbsp;
-  </div>
   <script type="text/javascript" src="../../js/libs/jquery/jquery-1.8.2.min.js"></script>
   <script type="text/javascript" src="../../js/jquery.spellchecker.js"></script>
   <script type="text/javascript">

--- a/src/js/jquery.spellchecker.js
+++ b/src/js/jquery.spellchecker.js
@@ -756,17 +756,43 @@
 
       var incorrectWords = data.data;
       var outcome = 'success';
+      var already_ignored_array = [];
+      var already_ignored_string = sessionStorage.ignoredWords;
+      var final_mispels = [];
+      final_mispels[0] = [];
 
+      // Have we already chosen to ignore this word?
+      if(already_ignored_string) {
+          already_ignored_array = JSON.parse(already_ignored_string); 
+      } 
+
+       // Do we have mispels?
       $.each(incorrectWords, function(i, words) {
+
         if (words.length) {
-          outcome = 'fail';
-          return false;
+            
+            $.each(words, function(key, word) {
+                
+                // Is the mispelt word in our array of ignored words?
+                var ignored_word_index = $.inArray(word , already_ignored_array);
+
+                if(ignored_word_index === -1) {
+                    //console.log("Add " + word + " at " + key + " from the array at position " + i + " to our final list" );
+                    final_mispels[0].push(word);
+                } 
+            }); 
+
+            /// Are there still words left in the incorrectWords array?
+            if(final_mispels[0].length) {
+                 outcome = 'fail';
+                 return false;  
+            }
         }
       });
 
       this.trigger('check.complete');
-      this.trigger('check.' + outcome, incorrectWords);
-      this.trigger(callback, incorrectWords);
+      this.trigger('check.' + outcome, final_mispels);
+      this.trigger(callback, final_mispels);
 
     }.bind(this);
   };
@@ -792,7 +818,34 @@
 
   SpellChecker.prototype.onIgnoreWord = function(e, word, element) {
     e.preventDefault();
-    this.replaceWord(this.incorrectWord, this.incorrectWord);
+   
+    // What word do we want to ignore?
+    var wordToIgnore = this.incorrectWord;
+
+    // Have we already ignored this word?
+    var already_ignored_string = sessionStorage.ignoredWords;
+    var already_ignored_array = [];
+
+    // Have we already chosen to ignore this word?
+    if(already_ignored_string) {
+       
+        already_ignored_array = JSON.parse(already_ignored_string); 
+
+        if($.inArray(wordToIgnore, already_ignored_array) === -1) {
+            already_ignored_array.push(wordToIgnore);
+        } 
+
+    } 
+    // This is the first word we're adding.
+    else {
+        already_ignored_array.push(wordToIgnore);
+    }
+
+    // Pop it in the DOM session storage
+    sessionStorage.setItem("ignoredWords", JSON.stringify(already_ignored_array));
+    
+    // Remove the word from the list of miss-spells
+    this.replaceWord(wordToIgnore, wordToIgnore);
   };
 
   SpellChecker.prototype.onIncorrectWordSelect = function(e, word, element, incorrectWords) {


### PR DESCRIPTION
### Problem

The user runs spell check, and ignores a word. They then continue to type and run the spell check again, the same words they've already ignored will be flagged again.
### Proposed Solution

Stores ignore words in the DOM `sessionStorage` object and remove from mis-spells list when the spell check is run. The isn't permanent storage, once the browser is closed completely these will be lost but I think permanently storing them might be an issue.
### Other

Also removed some stray div tags from the examples, and ignored OSX hidden files
