### PR TITLE
Update CKEditor plugin.js to detect window border and set position

### DIFF
--- a/src/examples/english/ckeditor/plugins/jqueryspellchecker/plugin.js
+++ b/src/examples/english/ckeditor/plugins/jqueryspellchecker/plugin.js
@@ -110,7 +110,7 @@ CKEDITOR.plugins.add('jqueryspellchecker', {
 	
     return function() {
 
-      	var ed = t.editor;
+	var ed = t.editor;
 	var word = (this.wordElement.data('firstElement') || this.wordElement)[0];
 	var element = this.wordElement.data('firstElement') || this.wordElement;
 	var offset = element.offset();
@@ -123,7 +123,7 @@ CKEDITOR.plugins.add('jqueryspellchecker', {
 
 	var left = p3.left + p2.left;
 	var top = p3.top + p2.top + (p1.top - p2.top) + word.offsetHeight;
-	var positionAbove =( p3.top + p2.top - word.offsetHeight ) - containerHeight;
+	var positionAbove =  p1.top + ( p3.top - $(ed.container.$).find('iframe').contents().find("html,body").scrollTop()  ) - containerHeight;	
 
 	top -= $(t.editorWindow).scrollTop();
 	

--- a/src/examples/english/ckeditor/plugins/jqueryspellchecker/plugin.js
+++ b/src/examples/english/ckeditor/plugins/jqueryspellchecker/plugin.js
@@ -110,27 +110,26 @@ CKEDITOR.plugins.add('jqueryspellchecker', {
 	
     return function() {
 
-      var ed = t.editor;
-      var word = (this.wordElement.data('firstElement') || this.wordElement)[0];
-	    var element = this.wordElement.data('firstElement') || this.wordElement;
-      var offset = element.offset();
-      var boxOffset = this.config.suggestBox.offset;
-	    var containerHeight = this.container.outerHeight();
-	    var positionAbove = (offset.top - containerHeight - boxOffset);
-      var positionBelow = (offset.top + element.outerHeight() + boxOffset);
+      	var ed = t.editor;
+	var word = (this.wordElement.data('firstElement') || this.wordElement)[0];
+	var element = this.wordElement.data('firstElement') || this.wordElement;
+	var offset = element.offset();
+	var boxOffset = this.config.suggestBox.offset;
+	var containerHeight = this.container.outerHeight();
 
-      var p1 = $(ed.container.$).find('iframe').offset();
-      var p2 = $(ed.container.$).offset();
-      var p3 = $(word).offset();
+	var p1 = $(ed.container.$).find('iframe').offset();
+	var p2 = $(ed.container.$).offset();
+	var p3 = $(word).offset();
 
-      var left = p3.left + p2.left;
-      var top = p3.top + p2.top + (p1.top - p2.top) + word.offsetHeight;
+	var left = p3.left + p2.left;
+	var top = p3.top + p2.top + (p1.top - p2.top) + word.offsetHeight;
+	var positionAbove =( p3.top + p2.top - word.offsetHeight ) - containerHeight;
 
-      top -= $(t.editorWindow).scrollTop();
+	top -= $(t.editorWindow).scrollTop();
 	
-		  if (win.height() + win.scrollTop() < positionBelow + containerHeight) {
-			  top = positionAbove;
-		  }
+	if (win.height() + win.scrollTop() < top + containerHeight) {
+		top = positionAbove;
+	}
 		
       this.container.css({ 
         top: top, 

--- a/src/examples/english/ckeditor/plugins/jqueryspellchecker/plugin.js
+++ b/src/examples/english/ckeditor/plugins/jqueryspellchecker/plugin.js
@@ -106,10 +106,18 @@ CKEDITOR.plugins.add('jqueryspellchecker', {
 
     var t = this;
 
+    var win = $(window);
+	
     return function() {
 
       var ed = t.editor;
       var word = (this.wordElement.data('firstElement') || this.wordElement)[0];
+	    var element = this.wordElement.data('firstElement') || this.wordElement;
+      var offset = element.offset();
+      var boxOffset = this.config.suggestBox.offset;
+	    var containerHeight = this.container.outerHeight();
+	    var positionAbove = (offset.top - containerHeight - boxOffset);
+      var positionBelow = (offset.top + element.outerHeight() + boxOffset);
 
       var p1 = $(ed.container.$).find('iframe').offset();
       var p2 = $(ed.container.$).offset();
@@ -119,7 +127,11 @@ CKEDITOR.plugins.add('jqueryspellchecker', {
       var top = p3.top + p2.top + (p1.top - p2.top) + word.offsetHeight;
 
       top -= $(t.editorWindow).scrollTop();
-
+	
+		  if (win.height() + win.scrollTop() < positionBelow + containerHeight) {
+			  top = positionAbove;
+		  }
+		
       this.container.css({ 
         top: top, 
         left: left  


### PR DESCRIPTION
Like classic library, we look if the bottom of the window is not too close. If it is, we set the position above.

It's a problem if the CKEditor is really near the window border. Could be improved with sides detection and offset.
